### PR TITLE
Allow options to Jade compiler

### DIFF
--- a/lib/browserify-plain-jade.js
+++ b/lib/browserify-plain-jade.js
@@ -10,7 +10,7 @@ module.exports = function(file, options) {
       options = {};
   }
 
-  options[filename] = file;
+  options['filename'] = file;
 
   var data = '';
 

--- a/lib/browserify-plain-jade.js
+++ b/lib/browserify-plain-jade.js
@@ -1,10 +1,16 @@
 var through = require('through');
 var jade = require('jade');
 
-module.exports = function(file) {
+module.exports = function(file, options) {
   if (!/\.jade$/.test(file)) {
     return through();
   }
+
+  if (options === undefined) {
+      options = {};
+  }
+
+  options[filename] = file;
 
   var data = '';
 
@@ -15,7 +21,7 @@ module.exports = function(file) {
   function end() {
     var that = this;
 
-    jade.render(data, {filename:file}, function(err, html) {
+    jade.render(data, options, function(err, html) {
       if (err) {
         that.emit('error', err);
         return;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/redhotvengeance/browserify-plain-jade",
   "main": "./lib/browserify-plain-jade",
   "dependencies": {
-    "jade": "^1.7.0",
+    "jade": "^1.9.0",
     "through": "^2.3.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browserify-plain-jade",
   "description": "browserify transform to compile Jade templates to HTML, leaving the parser behind.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": {
     "name": "Ian Lollar",
     "email": "rhv@redhotvengeance.com",


### PR DESCRIPTION
By simply having an `options` parameter, you can pass variables and options to the Jade compiler, just as `pretty` or globals to the template.
